### PR TITLE
Redirect users to start after sorting on paginated lists

### DIFF
--- a/src/__mocks__/app-router-mock.tsx
+++ b/src/__mocks__/app-router-mock.tsx
@@ -1,0 +1,32 @@
+// https://github.com/vercel/next.js/discussions/48937
+
+// Need to provide a mock implementation for the next/navigation router because the actual router is not available in the test environment.
+
+// React-testing-library only renders the component, doesn't have access to all the NextJs contexts
+
+import {
+	AppRouterContext,
+	AppRouterInstance
+} from 'next/dist/shared/lib/app-router-context.shared-runtime';
+import React from 'react';
+
+export type AppRouterContextProviderMockProps = {
+	router: Partial<AppRouterInstance>;
+	children: React.ReactNode;
+};
+
+export const AppRouterContextProviderMock = ({
+	router,
+	children
+}: AppRouterContextProviderMockProps): React.ReactNode => {
+	const mockedRouter: AppRouterInstance = {
+		back: jest.fn(),
+		forward: jest.fn(),
+		push: jest.fn(),
+		replace: jest.fn(),
+		refresh: jest.fn(),
+		prefetch: jest.fn(),
+		...router
+	};
+	return <AppRouterContext.Provider value={mockedRouter}>{children}</AppRouterContext.Provider>;
+};

--- a/src/components/pagination.test.tsx
+++ b/src/components/pagination.test.tsx
@@ -1,0 +1,167 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+// eslint-disable-next-line jest/no-mocks-import
+import { AppRouterContextProviderMock } from '@/__mocks__/app-router-mock';
+import { SearchParamsContext } from 'next/dist/shared/lib/hooks-client-context.shared-runtime';
+import PaginationBar from '@/components/pagination';
+
+// Mock the next navigation module
+// jest.mock('next/navigation', () => ({
+// 	__esModule: true,
+// 	usePathname: () => ({
+// 		pathname: ''
+// 	}),
+// 	useRouter: () => ({
+// 		replace: jest.fn(),
+// 		push: jest.fn(),
+// 		prefetch: jest.fn()
+// 	}),
+// 	useSearchParams: () => ({
+// 		get: () => {}
+// 	})
+// }));
+
+describe('Pagination', () => {
+	const defaultProps = {
+		currentPage: 1,
+		pageSize: 8,
+		itemCount: 100,
+		totalPagesToDisplay: 3
+	};
+
+	describe('Navigating to a new page', () => {
+		it('Should display correct page numbers', async () => {
+			const push = jest.fn();
+			const params = new URLSearchParams({ page: '2' });
+
+			render(
+				<SearchParamsContext.Provider value={params}>
+					<AppRouterContextProviderMock router={{ push }}>
+						<PaginationBar {...defaultProps} />
+					</AppRouterContextProviderMock>
+				</SearchParamsContext.Provider>
+			);
+
+			const page1Btn = screen.getByRole('button', { name: '1' });
+			const page2Btn = screen.getByRole('button', { name: '2' });
+			const page3Btn = screen.getByRole('button', { name: '3' });
+
+			expect(page1Btn).toBeInTheDocument();
+			expect(page2Btn).toBeInTheDocument();
+			expect(page3Btn).toBeInTheDocument();
+		});
+
+		it('Page numbers should navigate to the correct page', async () => {
+			// Arrange
+
+			const user = userEvent.setup();
+			const push = jest.fn();
+			const params = new URLSearchParams({ page: '2' });
+
+			render(
+				<SearchParamsContext.Provider value={params}>
+					<AppRouterContextProviderMock router={{ push }}>
+						<PaginationBar {...defaultProps} />
+					</AppRouterContextProviderMock>
+				</SearchParamsContext.Provider>
+			);
+
+			// Act
+			const page2Btn = screen.getByRole('button', { name: '2' });
+			await user.click(page2Btn);
+
+			// Assert
+			expect(page2Btn).toBeInTheDocument();
+			expect(push).toHaveBeenCalledTimes(1);
+			expect(push).toHaveBeenCalledWith('?page=2');
+		});
+
+		it('Previous button should navigate to the previous page', async () => {
+			// Arrange
+
+			const user = userEvent.setup();
+			const push = jest.fn();
+			const params = new URLSearchParams({ page: '1' });
+
+			render(
+				<SearchParamsContext.Provider value={params}>
+					<AppRouterContextProviderMock router={{ push }}>
+						<PaginationBar {...defaultProps} currentPage={2} />
+					</AppRouterContextProviderMock>
+				</SearchParamsContext.Provider>
+			);
+
+			const previousBtn = screen.getByRole('button', { name: 'Previous' });
+			await user.click(previousBtn);
+
+			expect(previousBtn).toBeInTheDocument();
+			expect(push).toHaveBeenCalledTimes(1);
+			expect(push).toHaveBeenCalledWith('?page=1');
+		});
+
+		it('Next button should navigate to the next page', async () => {
+			// Arrange
+			const user = userEvent.setup();
+			const push = jest.fn();
+			const params = new URLSearchParams({ page: '3' });
+
+			render(
+				<SearchParamsContext.Provider value={params}>
+					<AppRouterContextProviderMock router={{ push }}>
+						<PaginationBar {...defaultProps} currentPage={2} />
+					</AppRouterContextProviderMock>
+				</SearchParamsContext.Provider>
+			);
+
+			// Act
+			const nextBtn = screen.getByRole('button', { name: 'Next' });
+			await user.click(nextBtn);
+
+			// Assert
+			expect(nextBtn).toBeInTheDocument();
+			expect(push).toHaveBeenCalledTimes(1);
+			expect(push).toHaveBeenCalledWith('?page=3');
+		});
+
+		it('Previous button should be disabled when on the first page', async () => {
+			const user = userEvent.setup();
+			const push = jest.fn();
+			const params = new URLSearchParams({ page: '1' });
+
+			render(
+				<SearchParamsContext.Provider value={params}>
+					<AppRouterContextProviderMock router={{ push }}>
+						<PaginationBar {...defaultProps} />
+					</AppRouterContextProviderMock>
+				</SearchParamsContext.Provider>
+			);
+
+			const previousBtn = screen.getByRole('button', { name: 'Previous' });
+			await user.click(previousBtn);
+
+			expect(previousBtn).toBeInTheDocument();
+			expect(push).not.toHaveBeenCalled();
+		});
+
+		it('Next button should be disabled when on the last page', async () => {
+			const user = userEvent.setup();
+			const push = jest.fn();
+			const params = new URLSearchParams({ page: '14' });
+
+			render(
+				<SearchParamsContext.Provider value={params}>
+					<AppRouterContextProviderMock router={{ push }}>
+						<PaginationBar {...defaultProps} currentPage={13} />
+						{/* 13 is the last page */}
+					</AppRouterContextProviderMock>
+				</SearchParamsContext.Provider>
+			);
+
+			const nextBtn = screen.getByRole('button', { name: 'Next' });
+			await user.click(nextBtn);
+
+			expect(nextBtn).toBeInTheDocument();
+			expect(push).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/src/components/pagination.tsx
+++ b/src/components/pagination.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { useRouter, useSearchParams } from 'next/navigation';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+
+import { cn, getPageNumbers } from '@/lib/utils';
+import { Pagination, PaginationContent, PaginationItem } from '@/components/ui/pagination';
+import { Button } from '@/components/ui/button';
+
+interface Props {
+	currentPage: number;
+	pageSize: number;
+	itemCount: number;
+	totalPagesToDisplay?: number;
+}
+
+const PaginationBar = ({ currentPage, pageSize, itemCount, totalPagesToDisplay = 3 }: Props) => {
+	const router = useRouter();
+	const searchParams = useSearchParams();
+
+	const changePage = (p: number) => {
+		const params = new URLSearchParams(searchParams);
+		params.set('page', p.toString());
+		router.push(`?${params.toString()}`);
+	};
+
+	const totalPages = Math.ceil(itemCount / pageSize);
+
+	const renderPaginationItems = () => {
+		const pageNumbers = getPageNumbers(totalPages, currentPage, totalPagesToDisplay);
+		return pageNumbers.map((pageNumber) => (
+			<PaginationItem key={pageNumber} className='hidden sm:flex'>
+				<Button
+					variant='ghost'
+					onClick={() => changePage(pageNumber)}
+					className={cn(pageNumber === currentPage && 'bg-accent')}
+				>
+					{pageNumber}
+				</Button>
+			</PaginationItem>
+		));
+	};
+
+	return (
+		<Pagination>
+			<PaginationContent>
+				<PaginationItem>
+					<Button
+						variant='ghost'
+						disabled={currentPage <= 1}
+						onClick={() => changePage(currentPage - 1)}
+						className='group'
+					>
+						<ChevronLeft className='transition-all delay-150 duration-300 group-hover:-translate-x-1' />{' '}
+						Previous
+					</Button>
+				</PaginationItem>
+				{renderPaginationItems()}
+				<PaginationItem>
+					<Button
+						variant='ghost'
+						disabled={currentPage >= totalPages}
+						onClick={() => changePage(currentPage + 1)}
+						className='group'
+					>
+						Next
+						<ChevronRight className='transition-all delay-150 duration-300 group-hover:translate-x-1' />{' '}
+					</Button>
+				</PaginationItem>
+			</PaginationContent>
+		</Pagination>
+	);
+};
+
+export default PaginationBar;

--- a/src/components/sort-filter.test.tsx
+++ b/src/components/sort-filter.test.tsx
@@ -1,0 +1,130 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+// eslint-disable-next-line jest/no-mocks-import
+import { AppRouterContextProviderMock } from '@/__mocks__/app-router-mock';
+import { SearchParamsContext } from 'next/dist/shared/lib/hooks-client-context.shared-runtime';
+
+import SortFilter from '@/components/sort-filter';
+
+describe('Sort Filter', () => {
+	describe('Sorting a list of items', () => {
+		it('Sort button should be visible', async () => {
+			const push = jest.fn();
+			const params = new URLSearchParams({ page: '1' });
+
+			render(
+				<SearchParamsContext.Provider value={params}>
+					<AppRouterContextProviderMock router={{ push }}>
+						<SortFilter />
+					</AppRouterContextProviderMock>
+				</SearchParamsContext.Provider>
+			);
+
+			const sortButton = screen.getByRole('button', { name: 'Sort' });
+
+			expect(sortButton).toBeInTheDocument();
+		});
+
+		it('When clicked sort button should open sort menu', async () => {
+			// Arrange
+			const user = userEvent.setup();
+			const push = jest.fn();
+			const params = new URLSearchParams({ page: '1' });
+
+			render(
+				<SearchParamsContext.Provider value={params}>
+					<AppRouterContextProviderMock router={{ push }}>
+						<SortFilter />
+					</AppRouterContextProviderMock>
+				</SearchParamsContext.Provider>
+			);
+
+			// Act
+			const sortButton = screen.getByRole('button', { name: 'Sort' });
+			await user.click(sortButton);
+			const sortOptions = screen.getAllByRole('menuitemradio');
+
+			// Assert
+			expect(sortOptions).toHaveLength(6);
+		});
+
+		it('Should display the correct sort options', async () => {
+			// Arrange
+			const user = userEvent.setup();
+			const push = jest.fn();
+			const params = new URLSearchParams({ page: '1' });
+
+			render(
+				<SearchParamsContext.Provider value={params}>
+					<AppRouterContextProviderMock router={{ push }}>
+						<SortFilter />
+					</AppRouterContextProviderMock>
+				</SearchParamsContext.Provider>
+			);
+
+			// Act
+			const sortButton = screen.getByRole('button', { name: 'Sort' });
+			await user.click(sortButton);
+			const sortOptions = screen.getAllByRole('menuitemradio');
+
+			// Assert
+			expect(sortOptions).toHaveLength(6);
+			expect(sortOptions[0]).toHaveTextContent('Alphabetically, A-Z');
+			expect(sortOptions[1]).toHaveTextContent('Alphabetically, Z-A');
+			expect(sortOptions[2]).toHaveTextContent('Price, low-high');
+			expect(sortOptions[3]).toHaveTextContent('Price, high-low');
+			expect(sortOptions[4]).toHaveTextContent('Date, new-old');
+			expect(sortOptions[5]).toHaveTextContent('Date, old-new');
+		});
+
+		it('Should highlight correct sort option when clicked', async () => {
+			const user = userEvent.setup();
+			const push = jest.fn();
+			const params = new URLSearchParams({ page: '1' });
+
+			render(
+				<SearchParamsContext.Provider value={params}>
+					<AppRouterContextProviderMock router={{ push }}>
+						<SortFilter />
+					</AppRouterContextProviderMock>
+				</SearchParamsContext.Provider>
+			);
+
+			// Act
+			const sortButton = screen.getByRole('button', { name: 'Sort' });
+			await user.click(sortButton);
+
+			const sortOptions = screen.getAllByRole('menuitemradio');
+			await user.click(sortOptions[2]);
+
+			// Assert
+			// waitFor is used to wait for the sortFilter state to be updated
+			await waitFor(() => {
+				expect(sortOptions[2]).toHaveAttribute('aria-checked', 'true');
+			});
+		});
+
+		it('Should navigate to back to page 1 when a sort option is selected', async () => {
+			// Arrange
+			const user = userEvent.setup();
+			const push = jest.fn();
+			const params = new URLSearchParams({ page: '1' });
+
+			render(
+				<SearchParamsContext.Provider value={params}>
+					<AppRouterContextProviderMock router={{ push }}>
+						<SortFilter />
+					</AppRouterContextProviderMock>
+				</SearchParamsContext.Provider>
+			);
+
+			// Act
+			const sortButton = screen.getByRole('button', { name: 'Sort' });
+			await user.click(sortButton);
+			const sortOptions = screen.getAllByRole('menuitemradio');
+			await user.click(sortOptions[3]);
+
+			expect(push).toHaveBeenCalledWith('?page=1&sort=price-desc');
+		});
+	});
+});

--- a/src/components/sort-filter.tsx
+++ b/src/components/sort-filter.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useCallback, useState } from 'react';
-import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 
 import {
 	DropdownMenu,
@@ -16,7 +16,7 @@ import { Button } from '@/components/ui/button';
 
 const SortFilter = () => {
 	const router = useRouter();
-	const pathname = usePathname();
+	// const pathname = usePathname();
 	const searchParams = useSearchParams();
 
 	const [position, setPosition] = useState(searchParams.get('sort') || 'name-asc');
@@ -27,7 +27,7 @@ const SortFilter = () => {
 		(name: string, value: string) => {
 			const params = new URLSearchParams(searchParams.toString());
 			params.set(name, value);
-
+			params.set('page', '1'); // If user changes sort, reset page to 1
 			return params.toString();
 		},
 		[searchParams]
@@ -35,7 +35,8 @@ const SortFilter = () => {
 
 	const handleChange = (value: string) => {
 		setPosition(value);
-		router.push(`${pathname  }?${  createQueryString('sort', value)}`);
+		// Don't need pathname because we want to stay on same page and only change query params
+		router.push(`?${createQueryString('sort', value)}`);
 	};
 
 	return (

--- a/src/components/ui/pagination.tsx
+++ b/src/components/ui/pagination.tsx
@@ -1,0 +1,100 @@
+import * as React from 'react';
+import { ChevronLeftIcon, ChevronRightIcon, DotsHorizontalIcon } from '@radix-ui/react-icons';
+
+import { cn } from '@/lib/utils';
+import { ButtonProps, buttonVariants } from '@/components/ui/button';
+
+const Pagination = ({ className, ...props }: React.ComponentProps<'nav'>) => (
+	<nav
+		role='navigation'
+		aria-label='pagination'
+		className={cn('mx-auto flex w-full justify-center', className)}
+		{...props}
+	/>
+);
+Pagination.displayName = 'Pagination';
+
+const PaginationContent = React.forwardRef<HTMLUListElement, React.ComponentProps<'ul'>>(
+	({ className, ...props }, ref) => (
+		<ul ref={ref} className={cn('flex flex-row items-center gap-1', className)} {...props} />
+	)
+);
+PaginationContent.displayName = 'PaginationContent';
+
+const PaginationItem = React.forwardRef<HTMLLIElement, React.ComponentProps<'li'>>(
+	({ className, ...props }, ref) => <li ref={ref} className={cn('', className)} {...props} />
+);
+PaginationItem.displayName = 'PaginationItem';
+
+type PaginationLinkProps = {
+	isActive?: boolean;
+} & Pick<ButtonProps, 'size'> &
+	React.ComponentProps<'a'>;
+
+const PaginationLink = ({ className, isActive, size = 'icon', ...props }: PaginationLinkProps) => (
+	// Don't use this within pagination, using custom buttons
+	// eslint-disable-next-line jsx-a11y/anchor-has-content
+	<a
+		aria-current={isActive ? 'page' : undefined}
+		className={cn(
+			buttonVariants({
+				variant: isActive ? 'outline' : 'ghost',
+				size
+			}),
+			className
+		)}
+		{...props}
+	/>
+);
+PaginationLink.displayName = 'PaginationLink';
+
+const PaginationPrevious = ({
+	className,
+	...props
+}: React.ComponentProps<typeof PaginationLink>) => (
+	<PaginationLink
+		aria-label='Go to previous page'
+		size='default'
+		className={cn('gap-1 pl-2.5', className)}
+		{...props}
+	>
+		<ChevronLeftIcon className='h-4 w-4' />
+		<span>Previous</span>
+	</PaginationLink>
+);
+PaginationPrevious.displayName = 'PaginationPrevious';
+
+const PaginationNext = ({ className, ...props }: React.ComponentProps<typeof PaginationLink>) => (
+	<PaginationLink
+		aria-label='Go to next page'
+		size='default'
+		className={cn('gap-1 pr-2.5', className)}
+		{...props}
+	>
+		<span>Next</span>
+		<ChevronRightIcon className='h-4 w-4' />
+	</PaginationLink>
+);
+PaginationNext.displayName = 'PaginationNext';
+
+const PaginationEllipsis = ({ className, ...props }: React.ComponentProps<'span'>) => (
+	<span
+		aria-hidden
+		className={cn('flex h-9 w-9 items-center justify-center', className)}
+		{...props}
+	>
+		<DotsHorizontalIcon className='h-4 w-4' />
+		<span className='sr-only'>More pages</span>
+	</span>
+);
+PaginationEllipsis.displayName = 'PaginationEllipsis';
+
+export {
+	Pagination,
+	PaginationContent,
+	PaginationLink,
+	PaginationItem,
+	PaginationPrevious,
+	PaginationNext,
+	PaginationEllipsis
+};

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,4 +1,4 @@
-import { validateSortInput } from '@/lib/utils';
+import { validateSortInput, getPageNumbers } from '@/lib/utils';
 
 // Triple A structure
 
@@ -64,6 +64,61 @@ describe('Utilities - validateSortInput', () => {
 
 			expect(validation.sortField).toEqual('price');
 			expect(validation.sortValue).toEqual('desc');
+		});
+	});
+
+	describe('Utilities - getPageNumbers', () => {
+		describe('Generate Pagination Numbers', () => {
+			it('should return all page numbers when total pages is less than or equal to total pages to display', () => {
+				// Arrange
+				const totalPages = 3;
+				const currentPage = 2;
+				const totalPagesToDisplay = 5;
+				// Act
+				const pageNumbers = getPageNumbers(totalPages, currentPage, totalPagesToDisplay);
+				// Assert
+				expect(pageNumbers).toEqual([1, 2, 3]);
+			});
+
+			it('should return page numbers centered around the current page when total pages is greater than total pages to display', () => {
+				const totalPages = 10;
+				const currentPage = 5;
+				const totalPagesToDisplay = 5;
+
+				const pageNumbers = getPageNumbers(totalPages, currentPage, totalPagesToDisplay);
+
+				expect(pageNumbers).toEqual([3, 4, 5, 6, 7]);
+			});
+
+			it('should return page numbers starting from the beginning when current page is at the beginning', () => {
+				const totalPages = 10;
+				const currentPage = 1;
+				const totalPagesToDisplay = 5;
+
+				const pageNumbers = getPageNumbers(totalPages, currentPage, totalPagesToDisplay);
+
+				expect(pageNumbers).toEqual([1, 2, 3, 4, 5]);
+			});
+
+			it('should return page numbers ending at the end when current page is at the end', () => {
+				const totalPages = 10;
+				const currentPage = 10;
+				const totalPagesToDisplay = 5;
+
+				const pageNumbers = getPageNumbers(totalPages, currentPage, totalPagesToDisplay);
+
+				expect(pageNumbers).toEqual([6, 7, 8, 9, 10]);
+			});
+
+			it('should return single page number when total pages is 1', () => {
+				const totalPages = 1;
+				const currentPage = 1;
+				const totalPagesToDisplay = 5;
+
+				const pageNumbers = getPageNumbers(totalPages, currentPage, totalPagesToDisplay);
+
+				expect(pageNumbers).toEqual([1]);
+			});
 		});
 	});
 });

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -26,7 +26,33 @@ export const validateSortInput = (sortQuery: string | undefined) => {
 		(receivedSortValue === 'asc' || receivedSortValue === 'desc')
 	) {
 		return { sortField: receivedSortField, sortValue: receivedSortValue };
-	} 
-		return { sortField: defaultSortField, sortValue: 'asc' };
-	
+	}
+	return { sortField: defaultSortField, sortValue: 'asc' };
+};
+
+export const getPageNumbers = (
+	totalPages: number,
+	currentPage: number,
+	totalPagesToDisplay: number
+) => {
+	if (totalPages <= totalPagesToDisplay) {
+		return Array.from({ length: totalPages }, (_, i) => i + 1);
+	}
+	const half = Math.floor(totalPagesToDisplay / 2); // 2
+	// To ensure that the current page is always in the middle
+	let start = currentPage - half;
+	let end = currentPage + half;
+	// If the current page is near the start
+	if (start < 1) {
+		start = 1;
+		end = totalPagesToDisplay;
+	}
+	// If the current page is near the end
+	if (end > totalPages) {
+		start = totalPages - totalPagesToDisplay + 1;
+		end = totalPages;
+	}
+	return Array.from({ length: end - start + 1 }, (_, i) => start + i);
+
+	// TODO ADD ELLIPSIS IN MIDDLE
 };


### PR DESCRIPTION
## Description

This PR addresses the issue of not automatically redirecting the user to page one of the paginated list after sorting items while on a paginated list page other than page one.
Also adds tests for the sortFilter component

## Related Issue

- [x] Is this related to a specific issue? Is so please specify: #6 

## Type of Changes

Use a check for ✓ the following type of changes:

|     | Type                       |
| --- | -------------------------- |
|  ✓    | :bug: Bug fix              |
|   | :sparkles: New feature     |
|     | :hammer: Refactoring       |
|    ✓  | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Updates

## Testing Steps / QA Criteria

Ensure you have a paginated list with multiple pages.
Navigate to a page other than page one.
Sort the items.
Verify that you are automatically redirected to page one and the items are sorted accordingly.

## Checklist:

- [x] This PR is up to date with the development branch, and merge conflicts have been resolved
- [x] My code follows the style guidelines of this project
- [x] I have executed npm run lint and resolved any outstanding errors.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
